### PR TITLE
feat(classes): add batch cleanup endpoints and service cleanup logic

### DIFF
--- a/src/modules/classes/controllers/classes.controller.ts
+++ b/src/modules/classes/controllers/classes.controller.ts
@@ -115,4 +115,83 @@ export class ClassesController {
         return this.classesService.getAllBatchJobs();
     }
 
+    @Delete('assignments/batch/clear')
+    @HttpCode(HttpStatus.OK)
+    async cleanUpCompletedBatches() {
+        const beforeJobs = await this.classesService.getAllBatchJobs();
+        const beforeCount = beforeJobs.length;
+
+        console.log(`cleaning completed batches started...`, {
+            totalJobs: beforeCount,
+            context: 'ClassesController'
+        });
+
+        // Clean all completed batches (regardless of age)
+        const clearedCount = await this.classesService.cleanUpCompletedBatches();
+
+        const afterJobs = await this.classesService.getAllBatchJobs();
+        const remainingJobs = afterJobs.length;
+
+        return {
+            message: clearedCount === 0 ? 'No completed jobs to clear' : `Successfully cleared ${clearedCount} completed jobs`,
+            jobsCleared: clearedCount,
+            totalJobsBefore: beforeCount,
+            remainingJobs: remainingJobs,
+            operation: 'clear_completed'
+        };
+    }
+
+    @Delete('assignments/batch/clear/old')
+    @HttpCode(HttpStatus.OK)
+    async cleanUpOldBatches() {
+        const beforeJobs = await this.classesService.getAllBatchJobs();
+        const beforeCount = beforeJobs.length;
+
+        console.log(`cleaning old batches started...`, {
+            totalJobs: beforeCount,
+            context: 'ClassesController'
+        });
+
+        // Clean only old completed batches (24+ hours)
+        const clearedCount = await this.classesService.cleanUpOldBatches();
+
+        const afterJobs = await this.classesService.getAllBatchJobs();
+        const remainingJobs = afterJobs.length;
+
+        return {
+            message: clearedCount === 0 ? 'No old jobs to clear (older than 24 hours)' : `Successfully cleared ${clearedCount} old jobs`,
+            jobsCleared: clearedCount,
+            totalJobsBefore: beforeCount,
+            remainingJobs: remainingJobs,
+            operation: 'clear_old'
+        };
+    }
+
+    @Delete('assignments/batch/clear/all')
+    @HttpCode(HttpStatus.OK)
+    async cleanUpAllBatches() {
+        const beforeJobs = await this.classesService.getAllBatchJobs();
+        const beforeCount = beforeJobs.length;
+
+        console.log(`cleaning all batches started...`, {
+            totalJobs: beforeCount,
+            context: 'ClassesController'
+        });
+
+        // Clean ALL batches (for testing/development)
+        const clearedCount = await this.classesService.cleanUpAllBatches();
+
+        const afterJobs = await this.classesService.getAllBatchJobs();
+        const remainingJobs = afterJobs.length;
+
+        return {
+            message: clearedCount === 0 ? 'No jobs to clear' : `Successfully cleared all ${clearedCount} jobs`,
+            jobsCleared: clearedCount,
+            totalJobsBefore: beforeCount,
+            remainingJobs: remainingJobs,
+            operation: 'clear_all'
+        };
+    }
+
+
 }

--- a/src/modules/classes/services/classes.service.ts
+++ b/src/modules/classes/services/classes.service.ts
@@ -187,4 +187,30 @@ export class ClassesService {
         return this.batchProcessor.getAllBatchJob();
     }
 
+    async cleanUpOldBatches(): Promise<number> {
+        const jobs = this.batchProcessor.getAllBatchJob();
+        console.log(`cleaning old batches started...`, {
+            totalJobs: jobs.length,
+            context: 'ClassesService'
+        });
+        return this.batchProcessor.cleanUpOldJobs();
+    }
+
+    async cleanUpCompletedBatches(): Promise<number> {
+        const jobs = this.batchProcessor.getAllBatchJob();
+        console.log(`cleaning completed batches started...`, {
+            totalJobs: jobs.length,
+            context: 'ClassesService'
+        });
+        return this.batchProcessor.cleanUpCompletedJobs();
+    }
+
+    async cleanUpAllBatches(): Promise<number> {
+        const jobs = this.batchProcessor.getAllBatchJob();
+        console.log(`cleaning all batches started...`, {
+            totalJobs: jobs.length,
+            context: 'ClassesService'
+        });
+        return this.batchProcessor.cleanUpAllJobs();
+    }
 }


### PR DESCRIPTION
- Added batch cleanup routes in ClassesController:
  - DELETE /assignments/batch/clear — remove all completed jobs
  - DELETE /assignments/batch/clear/old — remove old jobs (>24 h)
  - DELETE /assignments/batch/clear/all — wipe all jobs for testing
- Extended BatchProcessorService with:
  - cleanUpOldJobs(), cleanUpCompletedJobs(), cleanUpAllJobs()
- Updated ClassesService to delegate cleanup operations to BatchProcessorService and log operations